### PR TITLE
No ylabel for posterior probability panels

### DIFF
--- a/pygtc/pygtc.py
+++ b/pygtc/pygtc.py
@@ -804,13 +804,6 @@ def plotGTC(chains, **kwargs):
                 #Update the font if needed
                 xLabel.set_fontproperties(tickFontProps)
 
-            ##### y label for top-left panel
-            if i==0:
-                if doOnly1dPlot:
-                    ax.set_ylabel('Probability', fontdict=customLabelFont)
-                elif paramNames is not None:
-                    ax.set_ylabel(paramNames[i], fontdict=customLabelFont)
-
             ##### First column and last row are needed to align labels
             if i==0:
                 axV.append(ax)


### PR DESCRIPTION
It previously displayed the parameter name on the y-axis, which doesn't make sense. Thanks @joergdietrich for catching this!