### PR TITLE
Changed `==` to `is` on line 397

### DIFF
--- a/pygtc/pygtc.py
+++ b/pygtc/pygtc.py
@@ -394,7 +394,7 @@ def plotGTC(chains, **kwargs):
 
     # Manage the sample point weights
     weights = kwargs.pop('weights', None)
-    if weights==None:
+    if weights is None:
         # Set unit weights if no weights are provided
         weights = [np.ones(len(chains[i])) for i in range(nChains)]
     else:


### PR DESCRIPTION
When sending a list or array for `weights` to the main function `plotGTC`, I received the `ValueError` message

`ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()`

This was related to `line 397`, which previously read `if weights==None:`; but an array/list cannot be compared to a value using `==` in python3. Instead, it must be contained within an `is` condition.  Thus, `line 397` now reads `if weights is None:`.

This fix created the behaviour as desired; namely that when using a weights array with my chains (primarily for use with multinest), the posteriors are properly bounded and represent the necessary structure.